### PR TITLE
feat(constraint): add the optional name field

### DIFF
--- a/dt_model/model/model.py
+++ b/dt_model/model/model.py
@@ -189,5 +189,7 @@ class Model:
         new_constraints = []
         for constraint in self.constraints:
             new_constraints.append(Constraint(constraint.usage.subs(change_indexes),
-                                              constraint.capacity.subs(change_capacities)))
+                                              constraint.capacity.subs(change_capacities),
+                                              group=constraint.group, name=constraint.name,
+            ))
         return Model(new_name, self.cvs, self.pvs, new_indexes, new_capacities, new_constraints)

--- a/dt_model/symbols/constraint.py
+++ b/dt_model/symbols/constraint.py
@@ -13,7 +13,16 @@ class Constraint:
     This class is used to define constraints for the model.
     """
 
-    def __init__(self, usage: Symbol, capacity: Symbol, group: str | None = None) -> None:
+    def __init__(
+        self, usage: Symbol, capacity: Symbol, group: str | None = None, name: str = ""
+    ) -> None:
         self.usage = usage
         self.capacity = capacity
+        self.name = name
+
+        # TODO(bassosimone): this field is only used by the view. We could consider
+        # deprecating it and moving the view mapping logic inside the view itself, which
+        # would work as intended as long as we have a working __hash__. By doing this,
+        # we would probably reduce the churn and coupling between the computational
+        # model and the related view.
         self.group = group


### PR DESCRIPTION
We need a name for the Constraint to map a Constraint class to its name and draw the corresponding median lines with a legend in overtourism. This commit is part of https://github.com/tn-aixpa/overtourism/issues/9 and we would need a corresponding commit in overtourism to take advantage of this functionality to plot medians along with a specific legend describing them.

Because the name was not previously exposed as a mandatory constructor field, I chose to make it an optional, default empty, field. This means that we don't break existing consumers using this API.

While there, note that group seems to be a very view specific field, so drop a note to investigate whether a different mapping based arragement is possible where the view keeps a map between a model entity and the view specific fields pertaining to it. This kind of arrangement could ot could not be feasible, considering how we are also cloning data structures, thus the comment mentions the need to consider and investigate only.